### PR TITLE
docs: fix readme items-to-show to carousel component

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ yarn add vue3-carousel
 
 ```vue
 <template>
-  <carousel>
-    <slide v-for="slide in 10" :key="slide" :items-to-show="1.5">
+  <carousel :items-to-show="1.5">
+    <slide v-for="slide in 10" :key="slide">
       {{ slide }}
     </slide>
 


### PR DESCRIPTION
Hi Ismail! I was using this carousel and it's awesome but I realised that readme maybe was wrong `:items-to-show` should go in `<carousel>` instead of `<slide>`