### PR TITLE
feat: add snapAlignCenterMode for snapAlign='center'

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,7 +52,7 @@ export default {
 | `itemsToScroll`        | 1        | number of slides to be scrolled                                                        |
 | ~~`currentSlide`~~     | ~~0~~    | ~~index number of the initial slide.~~ <Badge text="Deprecated 0.1.20" type="danger"/> |
 | `wrapAround`           | false    | enable infinite scrolling mode.                                                        |
-| `snapAlign`            | 'center' | controls the carousel position alignment, can be 'start', 'end', or 'center'           |
+| `snapAlign`            | 'center' | controls the carousel position alignment, can be 'start', 'end', 'center[-odd\|even]'  |
 | `transition`           | 300      | sliding transition time in ms.                                                         |
 | `settings`             | { }      | an object to pass all settings.                                                        |
 | `breakpoints`          | null     | an object to pass all the breakpoints settings.                                        |

--- a/src/components/Carousel.ts
+++ b/src/components/Carousel.ts
@@ -45,15 +45,7 @@ export default defineComponent({
       default: 'center',
       validator(value: string) {
         // The value must match one of these strings
-        return ['start', 'end', 'center'].includes(value);
-      },
-    },
-    // control snap position alignment -> center with odevity
-    snapAlignCenterMode: {
-      default: 'odd',
-      validator(value: string) {
-        // The value must match one of these strings
-        return ['odd', 'even'].includes(value);
+        return ['start', 'end', 'center', 'center-even', 'center-odd'].includes(value);
       },
     },
     // sliding transition time in ms
@@ -194,7 +186,8 @@ export default defineComponent({
       paginationCount.value = slides.value.length;
       slidesCount.value = slides.value.length;
       middleSlide.value = Math.ceil((slidesCount.value - 1) / 2);
-      currentSlide.value = Math.min(slidesCount.value - 1, currentSlide.value);
+      currentSlide.value =
+        slidesCount.value <= 0 ? 0 : Math.min(slidesCount.value - 1, currentSlide.value);
     }
 
     function updateSlidesBuffer(): void {
@@ -353,12 +346,11 @@ export default defineComponent({
      */
     const slidesToScroll = computed((): number => {
       let output = slidesBuffer.value.indexOf(currentSlide.value);
-      if (config.snapAlign === 'center') {
-        // TODO can try to handle overflow-error
-        const odevity = config.snapAlignCenterMode == 'odd' ? 1 : 2;
-        output -= (config.itemsToShow - odevity) / 2;
-      }
-      if (config.snapAlign === 'end') {
+      if (config.snapAlign === 'center' || config.snapAlign === 'center-odd') {
+        output -= (config.itemsToShow - 1) / 2;
+      } else if (config.snapAlign === 'center-even') {
+        output -= (config.itemsToShow - 2) / 2;
+      } else if (config.snapAlign === 'end') {
         output -= config.itemsToShow - 1;
       }
 


### PR DESCRIPTION
# Scene demand

![image](https://user-images.githubusercontent.com/30054881/136703738-96820a7d-cd49-469e-a48f-b571340b5c1d.png)

# Little desire
Sometimes you need to center an even number of data in a component.
I'm sure most people will feel the need to add this prop.
 Looking forward to reply

`Thanks for your open source~` Thanks♪(･ω･)ﾉ