### PR TITLE
Fix "Maximum call stack size exceeded" error when setting the slide initially but the slide list is empty

### DIFF
--- a/src/components/Carousel.ts
+++ b/src/components/Carousel.ts
@@ -296,12 +296,11 @@ export default defineComponent({
      */
     const isSliding = ref(false);
     function slideTo(slideIndex: number, mute = false): void {
-      if (currentSlide.value === slideIndex || isSliding.value) {
-        return;
-      }
-
       // Wrap slide index
       const lastSlideIndex = slidesCount.value - 1;
+      if (lastSlideIndex < 0 || currentSlide.value === slideIndex || isSliding.value) {
+        return;
+      }
       if (slideIndex > lastSlideIndex) {
         return slideTo(slideIndex - slidesCount.value);
       }


### PR DESCRIPTION
Thanks for your contribution to the community through vue3-carousel but recently there was a "Maximum call stack size exceeded" error when setting the initial current slide value while the list of slides was not loaded.
Issues: https://github.com/ismail9k/vue3-carousel/issues/98
![image](https://user-images.githubusercontent.com/18624860/136708465-7ebd7391-c75e-46ef-9d6a-1506dd0c1e89.png)

Solution I suggest: check and break the slideTo function if the list of slides is empty.