### PR TITLE
Added aria-label to navigation and pagination buttons

### DIFF
--- a/src/components/Navigation.ts
+++ b/src/components/Navigation.ts
@@ -10,12 +10,22 @@ const Navigation = (props: any, { slots, attrs }: any) => {
 
   const prevButton = h(
     'button',
-    { type: 'button', class: ['carousel__prev', attrs?.class] , onClick: nav.prev },
+    {
+      type: 'button',
+      class: ['carousel__prev', attrs?.class],
+      'aria-label': `Navigate to previous slide`,
+      onClick: nav.prev,
+    },
     slotPrev?.() || h(Icon, { name: 'arrowLeft' })
   );
   const nextButton = h(
     'button',
-    { type: 'button', class: ['carousel__next', attrs?.class], onClick: nav.next },
+    {
+      type: 'button',
+      class: ['carousel__next', attrs?.class],
+      'aria-label': `Navigate to next slide`,
+      onClick: nav.next,
+    },
     slotNext?.() || h(Icon, { name: 'arrowRight' })
   );
 

--- a/src/components/Pagination.ts
+++ b/src/components/Pagination.ts
@@ -29,6 +29,7 @@ const Pagination = () => {
         'carousel__pagination-button': true,
         'carousel__pagination-button--active': isActive(slide),
       },
+      'aria-label': `Navigate to slide ${slide + 1}`,
       onClick: () => handleButtonClick(slide),
     });
     const item = h('li', { class: 'carousel__pagination-item', key: slide }, button);


### PR DESCRIPTION
In the current implementation of this library, a lighthouse error is triggered for accessibility concerns for the pagination buttons. I added aria labels that are descriptive to both the navigation arrows as well as the pagination buttons. 