### PR TITLE
fix: Carousel needed double clicks for clicks to work

### DIFF
--- a/src/components/Carousel.ts
+++ b/src/components/Carousel.ts
@@ -297,9 +297,9 @@ export default defineComponent({
     }, 16);
 
     function handleDragStart(event: MouseEvent & TouchEvent): void {
-      if (!isTouch) event.preventDefault();
-
       isTouch = event.type === 'touchstart';
+
+      if (!isTouch) event.preventDefault();
       if ((!isTouch && event.button !== 0) || isSliding.value) {
         return;
       }


### PR DESCRIPTION
Fixes #121.

When first entering the `handleDragStart` function, the `isTouch` variable was initially `false`. Its assignment was moved to the top of the function.