### PR TITLE
Fix #issue-1072291456

### DIFF
--- a/src/partials/utils.ts
+++ b/src/partials/utils.ts
@@ -114,6 +114,11 @@ export function getSlidesToScroll({
   snapAlign: string,
 }): number {
   let output = slidesBuffer.indexOf(currentSlide);
+  
+  if (output === -1) {
+    output = slidesBuffer.indexOf(Math.ceil(currentSlide));
+  }
+  
   if (snapAlign === 'center' || snapAlign === 'center-odd') {
     output -= (itemsToShow - 1) / 2;
   } else if (snapAlign === 'center-even') {


### PR DESCRIPTION
## Description
This check fixes bug https://github.com/ismail9k/vue3-carousel/issues/133#issue-1072291456

This adds an additional check for the case when `currentSlide` passed to the getSlidesToScroll function as a fraction number. It happens when the last item in the non-wrapped carousel is rendered partial.

## Examples
### Bug:
![before](https://user-images.githubusercontent.com/84713941/158455452-4c8c9c63-e06c-49f5-9836-ee2ae5752033.gif)
### Fix:
![after](https://user-images.githubusercontent.com/84713941/158455440-c31fe0b9-84f7-4192-9871-c608d2ca66e2.gif)

## Code for the component to test

```
<template>
  <Carousel :items-to-show="2.5" :settings="settings" id="hideArrowsExample">
    <Slide v-for="slide in 5" :key="slide">
      <div class="carousel__item">{{ slide }}</div>
    </Slide>

    <template #addons>
      <Navigation />
    </template>
  </Carousel>
</template>

<script>
import { defineComponent } from 'vue';
import { Carousel, Slide, Navigation } from '../../dist/carousel.es';

import '../../dist/carousel.css';

export default defineComponent({
  name: 'HiddenArrows',
  components: {
    Carousel,
    Slide,
    Navigation,
  },
  data() {
    return {
      settings: {
        itemsToShow: 2.5,
        snapAlign: 'start',
      }
    }
  }
});
</script>

<style>
#hideArrowsExample .carousel__prev--in-active,
#hideArrowsExample .carousel__next--in-active {
  display: none;
}
</style>
```