### PR TITLE
chore: fix types generation

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,4 +10,9 @@ module.exports = {
   moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, {
     prefix: '<rootDir>',
   }),
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.test.json',
+    },
+  },
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
       "@/*": ["src/*"]
     }
   },
-  "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"],
+  "references": [{ "path": "./tsconfig.test.json" }]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": true
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"],
+}


### PR DESCRIPTION
Now `index.d.ts` should be directly in `dist` folder, and it won't be ignored

Closes #184 
Closes #10 