### PR TITLE
fix: Fixed click event inside slide on touch devices

### DIFF
--- a/src/components/Carousel.ts
+++ b/src/components/Carousel.ts
@@ -326,7 +326,7 @@ export default defineComponent({
       )
 
       // Prevent clicking if there is clicked slides
-      if (draggedSlides) {
+      if (draggedSlides && !isTouch) {
         const captureClick = (e: MouseEvent) => {
           e.stopPropagation()
           window.removeEventListener('click', captureClick, true)


### PR DESCRIPTION
It fixes #193 issue. Before on touch devices it was necessary  double click to fire event.