### PR TITLE
fix: allow clicks on input

### DIFF
--- a/src/components/Carousel.ts
+++ b/src/components/Carousel.ts
@@ -192,6 +192,9 @@ export default defineComponent({
     }
 
     function handleDragStart(event: MouseEvent & TouchEvent): void {
+      if (["INPUT", "TEXTAREA"].includes((event.target as HTMLElement).tagName)) {
+        return
+      }
       isTouch = event.type === 'touchstart'
 
       if ((!isTouch && event.button !== 0) || isSliding.value) {


### PR DESCRIPTION
fix https://github.com/ismail9k/vue3-carousel/issues/226 https://github.com/ismail9k/vue3-carousel/issues/220

input tag is clickable
Instead the input tag will not be draggable