### PR TITLE
Add `throttle` to allow customization of drag throttle

### DIFF
--- a/src/components/Carousel.ts
+++ b/src/components/Carousel.ts
@@ -149,6 +149,7 @@ export default defineComponent({
       nextTick(() => {
         updateSlidesData()
         updateSlideWidth()
+        createDragListener();
         emit('init')
       })
 
@@ -211,15 +212,19 @@ export default defineComponent({
       document.addEventListener(isTouch ? 'touchend' : 'mouseup', handleDragEnd, true)
     }
 
-    const handleDragging = throttle((event: MouseEvent & TouchEvent): void => {
-      endPosition.x = isTouch ? event.touches[0].clientX : event.clientX
-      endPosition.y = isTouch ? event.touches[0].clientY : event.clientY
-      const deltaX = endPosition.x - startPosition.x
-      const deltaY = endPosition.y - startPosition.y
+    let handleDragging = () => { /* */ }
+    function createDragListener() {
+     handleDragging = throttle((event: MouseEvent & TouchEvent): void => {
+        endPosition.x = isTouch ? event.touches[0].clientX : event.clientX
+        endPosition.y = isTouch ? event.touches[0].clientY : event.clientY
+        const deltaX = endPosition.x - startPosition.x
+        const deltaY = endPosition.y - startPosition.y
 
-      dragged.y = deltaY
-      dragged.x = deltaX
-    }, 16)
+        dragged.y = deltaY
+        dragged.x = deltaX
+      }, config.throttle ?? 16);
+    }
+
 
     function handleDragEnd(): void {
       const direction = config.dir === 'rtl' ? -1 : 1

--- a/src/partials/defaults.ts
+++ b/src/partials/defaults.ts
@@ -8,6 +8,7 @@ export const defaultConfigs: CarouselConfig = {
   autoplay: 0,
   snapAlign: 'center',
   wrapAround: false,
+  throttle: 16,
   pauseAutoplayOnHover: false,
   mouseDrag: true,
   touchDrag: true,

--- a/src/partials/props.ts
+++ b/src/partials/props.ts
@@ -16,6 +16,11 @@ export const carouselProps = {
     default: defaultConfigs.wrapAround,
     type: Boolean,
   },
+  // control max drag
+  throttle: {
+    default: defaultConfigs.throttle,
+    type: Number,
+  },
   // control snap position alignment
   snapAlign: {
     default: defaultConfigs.snapAlign,

--- a/src/types/carousel.ts
+++ b/src/types/carousel.ts
@@ -8,6 +8,7 @@ export interface CarouselConfig {
   itemsToScroll: number
   modelValue?: number
   transition?: number
+  throttle?: number
   autoplay?: number
   snapAlign: SnapAlign
   wrapAround?: boolean

--- a/src/utils/throttle.ts
+++ b/src/utils/throttle.ts
@@ -6,6 +6,9 @@
 // eslint-disable-next-line no-unused-vars
 export function throttle(fn: (...args: any[]) => unknown, limit: number): typeof fn {
   let inThrottle: boolean
+  if (!limit) {
+    return fn;
+  }
   return function (...args: any[]) {
     const self = this
     if (!inThrottle) {


### PR DESCRIPTION
By default, this library throttles the drag function on the carousel. This may not be desirable, or a custom throttle value might want to be preferred.

