### PR TITLE
enhance getSlidesVNodes logic

### DIFF
--- a/src/utils/getSlidesVNodes.ts
+++ b/src/utils/getSlidesVNodes.ts
@@ -1,10 +1,17 @@
-export function getSlidesVNodes(vNode: any[] | undefined) {
-  // Return empty array if there's any node
+import { Fragment } from 'vue'
+
+export function getSlidesVNodes(vNode?: any[]): any {
   if (!vNode) return []
 
-  // Check if the Slides components are added directly without v-for (#72)
-  if (vNode[0]?.children === "v-if" || vNode[0]?.type?.name === 'CarouselSlide') return vNode.filter((node: any) => node.type?.name === "CarouselSlide")
+  return vNode.reduce((acc, node) => {
+    if (node.type === Fragment) {
+      return [...acc, ...getSlidesVNodes(node.children)]
+    }
 
+    if (node.type?.name === 'CarouselSlide') {
+      return [...acc, node]
+    }
 
-  return vNode[0]?.children || []
+    return acc
+  }, [])
 }


### PR DESCRIPTION
Enhance getSlidesVNodes logic to recursively get nested child elements when the vNode type is Symobl(Fragment) 

fixes #291
fixes #277
fixes #72