### PR TITLE
[Pagination] Apply hover classes only on supported devices

### DIFF
--- a/src/styles/navigation.css
+++ b/src/styles/navigation.css
@@ -20,11 +20,6 @@
   transform: translateY(-50%);
 }
 
-.carousel__prev:hover,
-.carousel__next:hover {
-  color: var(--vc-nav-color-hover);
-}
-
 .carousel__next--disabled,
 .carousel__prev--disabled {
   cursor: not-allowed;
@@ -47,4 +42,11 @@
 .carousel--rtl .carousel__next {
   right: auto;
   left: 0;
+}
+
+@media (hover: hover) {
+  .carousel__prev:hover,
+  .carousel__next:hover {
+    color: var(--vc-nav-color-hover);
+  }
 }

--- a/src/styles/pagination.css
+++ b/src/styles/pagination.css
@@ -25,7 +25,12 @@
   background-color: var(--vc-pgn-background-color);
 }
 
-.carousel__pagination-button:hover::after,
 .carousel__pagination-button--active::after {
   background-color: var(--vc-pgn-active-color);
+}
+
+@media(hover: hover) {
+  .carousel__pagination-button:hover::after {
+    background-color: var(--vc-pgn-active-color);
+  }
 }


### PR DESCRIPTION
This PR wraps the hover classes under the [hover media feature](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/hover) so that they are only applied when supported.

This would fix issue #320 