### PR TITLE
allows successors to prevent default.

### DIFF
--- a/src/components/Carousel.ts
+++ b/src/components/Carousel.ts
@@ -223,7 +223,6 @@ export default defineComponent({
       // Prevent clicking if there is clicked slides
       if (draggedSlides && !isTouch) {
         const captureClick = (e: MouseEvent) => {
-          e.stopPropagation()
           window.removeEventListener('click', captureClick, true)
         }
         window.addEventListener('click', captureClick, true)


### PR DESCRIPTION
Resolves #362 by removing the `stopPropagation` in the _captured_ `dragend` event of the carousel.