### PR TITLE
Full support for esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,22 @@
     "type": "git",
     "url": "https://github.com/ismail9k/vue3-carousel.git"
   },
+  "exports": {
+    ".": {
+      "types": "./dist/carousel.d.ts",
+      "import": "./dist/carousel.es.js",
+      "require": "./dist/carousel.js"
+    },
+    "./dist/carousel": {
+      "types": "./dist/carousel.d.ts",
+      "import": "./dist/carousel.es.js",
+      "require": "./dist/carousel.js"
+    },
+    "./dist/*.css": {
+      "import": "./dist/*.css",
+      "require": "./dist/*.css"
+    }
+  },
   "main": "dist/carousel.js",
   "module": "dist/carousel.es.js",
   "style": "dist/carousel.css",


### PR DESCRIPTION
resolves external issue https://github.com/gaetansenn/vue3-carousel-nuxt/issues/12 and maybe #372.

Node's resolver loads "./dist/carousel.js" as "esm"!

I improved `package.json` with the help of https://github.com/vitejs/vite/discussions/2657#discussioncomment-5856909.