### PR TITLE
Stop using Capture phase events

### DIFF
--- a/src/components/Carousel.ts
+++ b/src/components/Carousel.ts
@@ -236,10 +236,9 @@ export default defineComponent({
       isDragging.value = false
       document.removeEventListener(
         isTouch ? 'touchmove' : 'mousemove',
-        handleDragging,
-        true
+        handleDragging
       )
-      document.removeEventListener(isTouch ? 'touchend' : 'mouseup', handleDragEnd, true)
+      document.removeEventListener(isTouch ? 'touchend' : 'mouseup', handleDragEnd)
     }
 
     /**

--- a/src/components/Carousel.ts
+++ b/src/components/Carousel.ts
@@ -198,8 +198,8 @@ export default defineComponent({
       startPosition.x = isTouch ? event.touches[0].clientX : event.clientX
       startPosition.y = isTouch ? event.touches[0].clientY : event.clientY
 
-      document.addEventListener(isTouch ? 'touchmove' : 'mousemove', handleDragging, true)
-      document.addEventListener(isTouch ? 'touchend' : 'mouseup', handleDragEnd, true)
+      document.addEventListener(isTouch ? 'touchmove' : 'mousemove', handleDragging)
+      document.addEventListener(isTouch ? 'touchend' : 'mouseup', handleDragEnd)
     }
 
     const handleDragging = throttle((event: MouseEvent & TouchEvent): void => {


### PR DESCRIPTION
This fixes #390 - elements further "down" DOM can't stop events reaching the Carousel because the Carousel uses Capture events, which start in the root of the DOM and work their way down to child elements. As such, they happen before anything inside the Carousel has a chance to handle them. This means it's impossible to prevent the Carousel from sliding from a child element (for example, an interactive component in a Slide).

Probably my lack of relevant skills, but I couldn't get the dependencies of this project to resolve in a clean VM, and after some hackery to get around that I got some Vue render-time errors related to refs which I didn't understand. As such, I haven't been able to properly test this change.