### PR TITLE
fix: invalid type for prop `height`

### DIFF
--- a/src/partials/props.ts
+++ b/src/partials/props.ts
@@ -29,7 +29,7 @@ export const carouselProps = {
   // control the gap between slides
   height: {
     default: DEFAULT_CONFIG.height,
-    type: Number,
+    type: [Number, String],
   },
   // control snap position alignment
   snapAlign: {


### PR DESCRIPTION
- closes: https://github.com/ismail9k/vue3-carousel/issues/424