### PR TITLE
docs: enable local search

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -37,6 +37,10 @@ module.exports = {
       },
     ],
 
+    search: {
+      provider: 'local'
+    },
+
     editLink: {
       pattern: 'https://github.com/ismail9k/vue3-carousel/edit/master/docs/:path',
     },


### PR DESCRIPTION
I was trying to look something up in the docs and noticed that local search was not enabled in VitePress. It looks like this:

![grafik](https://github.com/user-attachments/assets/ca13ef2a-87eb-4231-9022-5071f25dcf2e)
