### PR TITLE
Lower default drag threshold

### DIFF
--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -46,7 +46,7 @@ export const SNAP_ALIGN_OPTIONS = [
 ] as const
 
 export const DEFAULT_MOUSE_WHEEL_THRESHOLD = 10
-export const DEFAULT_DRAG_THRESHOLD = 0.3
+export const DEFAULT_DRAG_THRESHOLD = 0.15
 
 export const DEFAULT_CONFIG: CarouselConfig = {
   autoplay: 0,


### PR DESCRIPTION
It's still very hard on mobile to drag single slides

We should lower the default drag threshold even more