### PR TITLE
Adding Property to allow the Navigation to react to the ItemsToScroll Property

### DIFF
--- a/src/components/Navigation/Navigation.ts
+++ b/src/components/Navigation/Navigation.ts
@@ -13,6 +13,9 @@ export const Navigation = defineComponent<NavigationProps>({
     carousel: {
       type: Object as PropType<NavigationProps['carousel']>,
     },
+    complyWithItemsToScroll: {
+        type: Boolean
+    }
   },
   setup(props, { slots, attrs }) {
     let carousel = inject(injectCarousel, null)!
@@ -43,7 +46,7 @@ export const Navigation = defineComponent<NavigationProps>({
       () => !carousel.config.wrapAround && carousel.currentSlide <= carousel.minSlide
     )
     const nextDisabled = computed(
-      () => !carousel.config.wrapAround && carousel.currentSlide >= carousel.maxSlide
+      () => !carousel.config.wrapAround && carousel.currentSlide >= (carousel.maxSlide + (1 - (props.complyWithItemsToScroll ? carousel.config.itemsToScroll : 1 )))
     )
 
     return () => {

--- a/src/components/Navigation/Navigation.types.ts
+++ b/src/components/Navigation/Navigation.types.ts
@@ -1,5 +1,6 @@
 import { Carousel, CarouselExposed } from '@/components/Carousel'
 
 export type NavigationProps = {
-  carousel?: InstanceType<typeof Carousel> & CarouselExposed
+  carousel?: InstanceType<typeof Carousel> & CarouselExposed,
+  complyWithItemsToScroll: boolean
 }


### PR DESCRIPTION
When setting the `ItemsToScroll` Prop, the Pagination can adapt to that. 

Currently the Navigation cant, so if I have 4 Slides and `ItemsToScroll = 2` I can click the arrow another time (going from page 3 to 4), which is not the expected behavior (since nothing visually changes). 