### PR TITLE
fix navigation

### DIFF
--- a/src/components/Carousel/Carousel.css
+++ b/src/components/Carousel/Carousel.css
@@ -9,6 +9,7 @@
   position: relative;
   touch-action: pan-x pan-y pinch-zoom;
   z-index: 1;
+  --vc-transition-duration: 0.5s;
 }
 
 .carousel.is-dragging {
@@ -24,7 +25,7 @@
   padding: 0;
   position: relative;
   transition: transform ease-out;
-  transition-duration: var(--vc-transition-duration);
+  transition-duration: var(--vc-transition-duration, 0.5s);
   width: 100%;
 }
 
@@ -78,7 +79,7 @@
   opacity: 0;
   pointer-events: none;
   transition: opacity ease-in-out;
-  transition-duration: var(--vc-transition-duration);
+  transition-duration: var(--vc-transition-duration, 0.5s);
   width: 100%;
 }
 


### PR DESCRIPTION
closes  #531

Firefox handles undefined CSS variables in transitions more gracefully – it effectively ignores the variable and just skips the transition or uses the default. Chrome and Edge, on the other hand, treat the entire transition declaration as invalid if it contains an undefined variable, so the animation fails to work altogether.