### PR TITLE
feat: exclude invisible and cloned slides from tab navigation (#521)

### DIFF
--- a/src/components/Slide/Slide.ts
+++ b/src/components/Slide/Slide.ts
@@ -135,6 +135,7 @@ export const Slide = defineComponent({
           },
           id: props.isClone ? undefined : props.id,
           'aria-hidden': props.isClone || undefined,
+          tabindex: props.isClone || !isVisible.value ? -1 : undefined,
         },
         slots.default?.({
           currentIndex: currentIndex.value,

--- a/tests/integration/__snapshots__/carousel.spec.ts.snap
+++ b/tests/integration/__snapshots__/carousel.spec.ts.snap
@@ -5,12 +5,12 @@ exports[`SSR Carousel > renders server side properly 1`] = `
   <section class="carousel is-ltr is-effect-slide" dir="ltr" style="--vc-carousel-height: 200px; --vc-cloned-offset: 0px; --vc-slide-gap: 0px;" aria-label="Gallery" tabindex="0">
     <div class="carousel__viewport">
       <ol class="carousel__track" style="transform: translateX(0px);">
-        <li style="width: 50%;" class="carousel__slide carousel__slide--clone" aria-hidden="true">5 <input type="text" tabindex="-1"></li>
+        <li style="width: 50%;" class="carousel__slide carousel__slide--clone" aria-hidden="true" tabindex="-1">5 <input type="text" tabindex="-1"></li>
         <li style="width: 50%;" class="carousel__slide carousel__slide--visible carousel__slide--prev" id="v-0">1 <input type="text"></li>
         <li style="width: 50%;" class="carousel__slide carousel__slide--visible carousel__slide--active" id="v-1">2 <input type="text"></li>
         <li style="width: 50%;" class="carousel__slide carousel__slide--visible carousel__slide--next" id="v-2">3 <input type="text"></li>
-        <li style="width: 50%;" class="carousel__slide" id="v-3">4 <input type="text"></li>
-        <li style="width: 50%;" class="carousel__slide" id="v-4">5 <input type="text"></li>
+        <li style="width: 50%;" class="carousel__slide" id="v-3" tabindex="-1">4 <input type="text"></li>
+        <li style="width: 50%;" class="carousel__slide" id="v-4" tabindex="-1">5 <input type="text"></li>
       </ol>
     </div><button type="button" aria-label="Navigate to previous slide" title="Navigate to previous slide" class="carousel__prev"><svg class="carousel__icon" viewBox="0 0 24 24" role="img" aria-label="Arrow pointing to the left">
         <title>Arrow pointing to the left</title>
@@ -31,19 +31,19 @@ exports[`SSR Carousel > renders server side properly 1`] = `
 </div>"
 `;
 
-exports[`SSR Carousel > renders server side properly 2`] = `"<div id="app"><section class="carousel is-ltr is-effect-slide" dir="ltr" style="--vc-carousel-height:200px;--vc-cloned-offset:0px;--vc-slide-gap:0px;" aria-label="Gallery" tabindex="0"><div class="carousel__viewport"><ol class="carousel__track" style="transform:translateX(0px);"><!--[--><li style="width:50%;" class="carousel__slide carousel__slide--visible carousel__slide--prev" id="v-0">1 <input type="text"></li><li style="width:50%;" class="carousel__slide carousel__slide--visible carousel__slide--active" id="v-1">2 <input type="text"></li><li style="width:50%;" class="carousel__slide carousel__slide--visible carousel__slide--next" id="v-2">3 <input type="text"></li><li style="width:50%;" class="carousel__slide" id="v-3">4 <input type="text"></li><li style="width:50%;" class="carousel__slide" id="v-4">5 <input type="text"></li><!--]--></ol></div><!--[--><!--[--><button type="button" aria-label="Navigate to previous slide" title="Navigate to previous slide" class="carousel__prev"><svg class="carousel__icon" viewBox="0 0 24 24" role="img" aria-label="Arrow pointing to the left"><title>Arrow pointing to the left</title><path d="M15.41 16.59L10.83 12l4.58-4.59L14 6l-6 6 6 6 1.41-1.41z"></path></svg></button><button type="button" aria-label="Navigate to next slide" title="Navigate to next slide" class="carousel__next"><svg class="carousel__icon" viewBox="0 0 24 24" role="img" aria-label="Arrow pointing to the right"><title>Arrow pointing to the right</title><path d="M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z"></path></svg></button><!--]--><ol class="carousel__pagination"><li class="carousel__pagination-item"><button type="button" class="carousel__pagination-button" aria-label="Navigate to slide 1" aria-pressed="false" aria-controls="v-0" title="Navigate to slide 1"></button></li><li class="carousel__pagination-item"><button type="button" class="carousel__pagination-button carousel__pagination-button--active" aria-label="Navigate to slide 2" aria-pressed="true" aria-controls="v-1" title="Navigate to slide 2"></button></li><li class="carousel__pagination-item"><button type="button" class="carousel__pagination-button" aria-label="Navigate to slide 3" aria-pressed="false" aria-controls="v-2" title="Navigate to slide 3"></button></li><li class="carousel__pagination-item"><button type="button" class="carousel__pagination-button" aria-label="Navigate to slide 4" aria-pressed="false" aria-controls="v-3" title="Navigate to slide 4"></button></li><li class="carousel__pagination-item"><button type="button" class="carousel__pagination-button" aria-label="Navigate to slide 5" aria-pressed="false" aria-controls="v-4" title="Navigate to slide 5"></button></li></ol><!--]--><div class="carousel__liveregion carousel__sr-only" aria-live="polite" aria-atomic="true">Item 2 of 5</div></section></div>"`;
+exports[`SSR Carousel > renders server side properly 2`] = `"<div id="app"><section class="carousel is-ltr is-effect-slide" dir="ltr" style="--vc-carousel-height:200px;--vc-cloned-offset:0px;--vc-slide-gap:0px;" aria-label="Gallery" tabindex="0"><div class="carousel__viewport"><ol class="carousel__track" style="transform:translateX(0px);"><!--[--><li style="width:50%;" class="carousel__slide carousel__slide--visible carousel__slide--prev" id="v-0">1 <input type="text"></li><li style="width:50%;" class="carousel__slide carousel__slide--visible carousel__slide--active" id="v-1">2 <input type="text"></li><li style="width:50%;" class="carousel__slide carousel__slide--visible carousel__slide--next" id="v-2">3 <input type="text"></li><li style="width:50%;" class="carousel__slide" id="v-3" tabindex="-1">4 <input type="text"></li><li style="width:50%;" class="carousel__slide" id="v-4" tabindex="-1">5 <input type="text"></li><!--]--></ol></div><!--[--><!--[--><button type="button" aria-label="Navigate to previous slide" title="Navigate to previous slide" class="carousel__prev"><svg class="carousel__icon" viewBox="0 0 24 24" role="img" aria-label="Arrow pointing to the left"><title>Arrow pointing to the left</title><path d="M15.41 16.59L10.83 12l4.58-4.59L14 6l-6 6 6 6 1.41-1.41z"></path></svg></button><button type="button" aria-label="Navigate to next slide" title="Navigate to next slide" class="carousel__next"><svg class="carousel__icon" viewBox="0 0 24 24" role="img" aria-label="Arrow pointing to the right"><title>Arrow pointing to the right</title><path d="M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z"></path></svg></button><!--]--><ol class="carousel__pagination"><li class="carousel__pagination-item"><button type="button" class="carousel__pagination-button" aria-label="Navigate to slide 1" aria-pressed="false" aria-controls="v-0" title="Navigate to slide 1"></button></li><li class="carousel__pagination-item"><button type="button" class="carousel__pagination-button carousel__pagination-button--active" aria-label="Navigate to slide 2" aria-pressed="true" aria-controls="v-1" title="Navigate to slide 2"></button></li><li class="carousel__pagination-item"><button type="button" class="carousel__pagination-button" aria-label="Navigate to slide 3" aria-pressed="false" aria-controls="v-2" title="Navigate to slide 3"></button></li><li class="carousel__pagination-item"><button type="button" class="carousel__pagination-button" aria-label="Navigate to slide 4" aria-pressed="false" aria-controls="v-3" title="Navigate to slide 4"></button></li><li class="carousel__pagination-item"><button type="button" class="carousel__pagination-button" aria-label="Navigate to slide 5" aria-pressed="false" aria-controls="v-4" title="Navigate to slide 5"></button></li></ol><!--]--><div class="carousel__liveregion carousel__sr-only" aria-live="polite" aria-atomic="true">Item 2 of 5</div></section></div>"`;
 
 exports[`SSR Carousel > renders slotted server side properly 1`] = `
 "<div id="app">
   <section class="carousel is-ltr is-effect-slide" dir="ltr" style="--vc-carousel-height: auto; --vc-cloned-offset: 0px; --vc-slide-gap: 0px;" aria-label="Gallery" tabindex="0">
     <div class="carousel__viewport">
       <ol class="carousel__track" style="transform: translateX(0px);">
-        <li style="width: 100%;" class="carousel__slide carousel__slide--clone carousel__slide--prev" aria-hidden="true">5</li>
+        <li style="width: 100%;" class="carousel__slide carousel__slide--clone carousel__slide--prev" aria-hidden="true" tabindex="-1">5</li>
         <li style="width: 100%;" class="carousel__slide carousel__slide--visible carousel__slide--active" id="v-0">1</li>
-        <li style="width: 100%;" class="carousel__slide carousel__slide--next" id="v-1">2</li>
-        <li style="width: 100%;" class="carousel__slide" id="v-2">3</li>
-        <li style="width: 100%;" class="carousel__slide" id="v-3">4</li>
-        <li style="width: 100%;" class="carousel__slide" id="v-4">5</li>
+        <li style="width: 100%;" class="carousel__slide carousel__slide--next" id="v-1" tabindex="-1">2</li>
+        <li style="width: 100%;" class="carousel__slide" id="v-2" tabindex="-1">3</li>
+        <li style="width: 100%;" class="carousel__slide" id="v-3" tabindex="-1">4</li>
+        <li style="width: 100%;" class="carousel__slide" id="v-4" tabindex="-1">5</li>
       </ol>
     </div>
     <div class="carousel__liveregion carousel__sr-only" aria-live="polite" aria-atomic="true">Item 1 of 5</div>
@@ -51,24 +51,24 @@ exports[`SSR Carousel > renders slotted server side properly 1`] = `
 </div>"
 `;
 
-exports[`SSR Carousel > renders slotted server side properly 2`] = `"<div id="app"><section class="carousel is-ltr is-effect-slide" dir="ltr" style="--vc-carousel-height:auto;--vc-cloned-offset:0px;--vc-slide-gap:0px;" aria-label="Gallery" tabindex="0"><div class="carousel__viewport"><ol class="carousel__track" style="transform:translateX(0px);"><!--[--><!--[--><li style="width:100%;" class="carousel__slide carousel__slide--visible carousel__slide--active" id="v-0">1</li><li style="width:100%;" class="carousel__slide carousel__slide--next" id="v-1">2</li><li style="width:100%;" class="carousel__slide" id="v-2">3</li><li style="width:100%;" class="carousel__slide" id="v-3">4</li><li style="width:100%;" class="carousel__slide" id="v-4">5</li><!--]--><!--]--></ol></div><!--[--><!--]--><div class="carousel__liveregion carousel__sr-only" aria-live="polite" aria-atomic="true">Item 1 of 5</div></section></div>"`;
+exports[`SSR Carousel > renders slotted server side properly 2`] = `"<div id="app"><section class="carousel is-ltr is-effect-slide" dir="ltr" style="--vc-carousel-height:auto;--vc-cloned-offset:0px;--vc-slide-gap:0px;" aria-label="Gallery" tabindex="0"><div class="carousel__viewport"><ol class="carousel__track" style="transform:translateX(0px);"><!--[--><!--[--><li style="width:100%;" class="carousel__slide carousel__slide--visible carousel__slide--active" id="v-0">1</li><li style="width:100%;" class="carousel__slide carousel__slide--next" id="v-1" tabindex="-1">2</li><li style="width:100%;" class="carousel__slide" id="v-2" tabindex="-1">3</li><li style="width:100%;" class="carousel__slide" id="v-3" tabindex="-1">4</li><li style="width:100%;" class="carousel__slide" id="v-4" tabindex="-1">5</li><!--]--><!--]--></ol></div><!--[--><!--]--><div class="carousel__liveregion carousel__sr-only" aria-live="polite" aria-atomic="true">Item 1 of 5</div></section></div>"`;
 
 exports[`Wrap around Carousel.ts > renders wrapAround correctly 1`] = `
 "<section class="carousel is-ltr is-effect-slide" dir="ltr" style="--vc-carousel-height: auto; --vc-cloned-offset: 0px; --vc-slide-gap: 0px;" aria-label="Gallery" tabindex="0">
   <div class="carousel__viewport">
     <ol class="carousel__track" style="transform: translateX(0px);">
-      <li style="width: 33.333333333333336%;" class="carousel__slide" id="v-0">1 <input type="text"></li>
-      <li style="width: 33.333333333333336%;" class="carousel__slide" id="v-1">2 <input type="text"></li>
-      <li style="width: 33.333333333333336%;" class="carousel__slide" id="v-2">3 <input type="text"></li>
-      <li style="width: 33.333333333333336%;" class="carousel__slide" id="v-3">4 <input type="text"></li>
-      <li style="width: 33.333333333333336%;" class="carousel__slide" id="v-4">5 <input type="text"></li>
-      <li style="width: 33.333333333333336%;" class="carousel__slide" id="v-5">6 <input type="text"></li>
-      <li style="width: 33.333333333333336%;" class="carousel__slide" id="v-6">7 <input type="text"></li>
+      <li style="width: 33.333333333333336%;" class="carousel__slide" id="v-0" tabindex="-1">1 <input type="text"></li>
+      <li style="width: 33.333333333333336%;" class="carousel__slide" id="v-1" tabindex="-1">2 <input type="text"></li>
+      <li style="width: 33.333333333333336%;" class="carousel__slide" id="v-2" tabindex="-1">3 <input type="text"></li>
+      <li style="width: 33.333333333333336%;" class="carousel__slide" id="v-3" tabindex="-1">4 <input type="text"></li>
+      <li style="width: 33.333333333333336%;" class="carousel__slide" id="v-4" tabindex="-1">5 <input type="text"></li>
+      <li style="width: 33.333333333333336%;" class="carousel__slide" id="v-5" tabindex="-1">6 <input type="text"></li>
+      <li style="width: 33.333333333333336%;" class="carousel__slide" id="v-6" tabindex="-1">7 <input type="text"></li>
       <li style="width: 33.333333333333336%;" class="carousel__slide carousel__slide--visible carousel__slide--prev" id="v-7">8 <input type="text"></li>
       <li style="width: 33.333333333333336%;" class="carousel__slide carousel__slide--visible carousel__slide--active" id="v-8">9 <input type="text"></li>
-      <li style="width: 33.333333333333336%;" class="carousel__slide carousel__slide--clone carousel__slide--visible carousel__slide--next" aria-hidden="true">1 <input type="text" tabindex="-1"></li>
-      <li style="width: 33.333333333333336%;" class="carousel__slide carousel__slide--clone" aria-hidden="true">2 <input type="text" tabindex="-1"></li>
-      <li style="width: 33.333333333333336%;" class="carousel__slide carousel__slide--clone" aria-hidden="true">3 <input type="text" tabindex="-1"></li>
+      <li style="width: 33.333333333333336%;" class="carousel__slide carousel__slide--clone carousel__slide--visible carousel__slide--next" aria-hidden="true" tabindex="-1">1 <input type="text" tabindex="-1"></li>
+      <li style="width: 33.333333333333336%;" class="carousel__slide carousel__slide--clone" aria-hidden="true" tabindex="-1">2 <input type="text" tabindex="-1"></li>
+      <li style="width: 33.333333333333336%;" class="carousel__slide carousel__slide--clone" aria-hidden="true" tabindex="-1">3 <input type="text" tabindex="-1"></li>
     </ol>
   </div><button type="button" aria-label="Navigate to previous slide" title="Navigate to previous slide" class="carousel__prev"><svg class="carousel__icon" viewBox="0 0 24 24" role="img" aria-label="Arrow pointing to the left">
       <title>Arrow pointing to the left</title>

--- a/tests/integration/carousel.spec.ts
+++ b/tests/integration/carousel.spec.ts
@@ -16,7 +16,7 @@ describe('Carousel.ts', () => {
       props: {
         slideNum: 5,
         modelValue: 0,
-        'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
+        'onUpdate:modelValue': (e: number) => wrapper.setProps({ modelValue: e }),
       },
     })
   })
@@ -114,6 +114,60 @@ describe('Carousel.ts', () => {
     await wrapper.setProps({ itemsToShow: 10 })
     const slides = wrapper.findAll('.carousel__slide')
     expect(slides.length).toBe(5)
+  })
+
+  it('Should exclude invisible slides from tab navigation', async () => {
+    const wrapper = await mount(App, {
+      props: {
+        slideNum: 5,
+        itemsToShow: 1,
+        modelValue: 0,
+      },
+    })
+    
+    const allSlides = wrapper.findAll('.carousel__slide')
+    const visibleSlides = wrapper.findAll('.carousel__slide--visible')
+    
+    // With itemsToShow: 1, only 1 slide should be visible
+    expect(visibleSlides.length).toBe(1)
+    expect(allSlides.length).toBe(5)
+    
+    // Check that visible slide has no tabindex or has tabindex="0"
+    const visibleSlide = visibleSlides[0].element as HTMLElement
+    const visibleTabindex = visibleSlide.getAttribute('tabindex')
+    expect(visibleTabindex === null || visibleTabindex === '0').toBe(true)
+    
+    // Check that non-visible slides have tabindex="-1"
+    for (let i = 0; i < allSlides.length; i++) {
+      const slide = allSlides[i].element as HTMLElement
+      const hasVisibleClass = slide.classList.contains('carousel__slide--visible')
+      
+      if (!hasVisibleClass) {
+        expect(slide.getAttribute('tabindex')).toBe('-1')
+      }
+    }
+  })
+
+  it('Should exclude cloned slides from tab navigation', async () => {
+    const wrapper = await mount(App, {
+      props: {
+        slideNum: 5,
+        itemsToShow: 3,
+        wrapAround: true,
+        modelValue: 0,
+      },
+    })
+    
+    const clonedSlides = wrapper.findAll('.carousel__slide--clone')
+    
+    // With wrapAround, there should be cloned slides
+    expect(clonedSlides.length).toBeGreaterThan(0)
+    
+    // Check that cloned slides have tabindex="-1"
+    for (const clonedSlide of clonedSlides) {
+      const slide = clonedSlide.element as HTMLElement
+      expect(slide.getAttribute('tabindex')).toBe('-1')
+    }
   })
 })
 


### PR DESCRIPTION
**Title**  
Exclude invisible slides from keyboard focus (fix #521)

**Summary**  
- add `tabindex="-1"` to any Carousel slide that’s either cloned or outside the current `visibleRange` so hidden items can’t be tabbed  
- keep the existing `aria-hidden` behavior for clones and reuse the new tab logic for all hidden slides  
- extend integration coverage with two keyboard-accessibility specs (invisible slides + cloned slides) and refresh snapshots


**Related Issues**
- [Exclude invisible slider items from tab navigation #521
](https://github.com/ismail9k/vue3-carousel/issues/521)
**Testing**  
```pwsh
pnpm test
pnpm build
```